### PR TITLE
Allow multiple CATS backbone flexible regions

### DIFF
--- a/src/edu/duke/cs/osprey/confspace/CATSStrandFlex.java
+++ b/src/edu/duke/cs/osprey/confspace/CATSStrandFlex.java
@@ -38,8 +38,8 @@ import edu.duke.cs.osprey.minimization.ObjectiveFunction;
 import edu.duke.cs.osprey.minimization.ObjectiveFunction.DofBounds;
 import edu.duke.cs.osprey.structure.Molecule;
 import edu.duke.cs.osprey.structure.Residue;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -72,7 +72,7 @@ public class CATSStrandFlex extends StrandFlex {
     //For now let's just have CATS do a single backbone voxel
     @Override
     public ObjectiveFunction.DofBounds makeBounds(Strand strand) {
-        double freeDOFVoxel[][] = block.getFreeDOFVoxel();
+        double[][] freeDOFVoxel = block.getFreeDOFVoxel();
         int numDOFs = freeDOFVoxel[0].length;
         DofBounds ans = new DofBounds(numDOFs);
         for(int d=0; d<numDOFs; d++)
@@ -82,22 +82,17 @@ public class CATSStrandFlex extends StrandFlex {
     
     @Override
     public ArrayList<HashMap<String, double[]>> listBackboneVoxels(SimpleConfSpace.Position pos) {
-            if(doesBlockAffectResidue(pos.resNum))
-                return new ArrayList(Arrays.asList(defaultBackboneVoxel(pos.strand)));
-            else//No flexibility because pos not affected by these CATS DOFs
-                return new ArrayList<>();
-    }
-    
-    
-    private boolean doesBlockAffectResidue(String resNum){
-        List<Residue> resList = block.getResidues();
-        for(Residue res : resList){
-            if(res.getPDBResNumber().equalsIgnoreCase(resNum))
-                return true;
+        var retList = new ArrayList<HashMap<String, double[]>>();
+        if (doesBlockAffectResidue(pos.resNum)) {
+            retList.add(defaultBackboneVoxel(pos.strand));
         }
-        return false;
+
+        return retList;
     }
-    
-    
-    
+
+    private boolean doesBlockAffectResidue(String resNum){
+        return block.getResidues()
+                    .stream()
+                    .anyMatch((residue -> residue.getPDBResNumber().equalsIgnoreCase(resNum)));
+    }
 }

--- a/src/edu/duke/cs/osprey/confspace/SimpleConfSpace.java
+++ b/src/edu/duke/cs/osprey/confspace/SimpleConfSpace.java
@@ -858,11 +858,11 @@ public class SimpleConfSpace implements Serializable, ConfSpaceIteration {
 		return info;
 	}
         
-        public int getNumPos(){
-            return positions.size();
-        }
-        
-        private static HashMap<String,double[]> sidechainDOFBounds(Position pos, ResidueTemplate template, Integer rotamerIndex){
+    public int getNumPos(){
+        return positions.size();
+    }
+
+      private static HashMap<String,double[]> sidechainDOFBounds(Position pos, ResidueTemplate template, Integer rotamerIndex){
             //get bounds on the sidechain dihedrals associated with a particular rotamer
             if(rotamerIndex==null)//no dihedrals
                 return new HashMap<>();
@@ -880,27 +880,24 @@ public class SimpleConfSpace implements Serializable, ConfSpaceIteration {
         }
         
         
-        private ArrayList<HashMap<String,double[]>> listBackboneVoxels(Position pos){
-            ArrayList<HashMap<String,double[]> > ans = new ArrayList<>();
-            
-            for(StrandFlex flexType : strandFlex.get(pos.strand)){
-                ArrayList<HashMap<String,double[]> > flexTypeVox = flexType.listBackboneVoxels(pos);
-                if( (!flexTypeVox.isEmpty()) && (!ans.isEmpty()) ){
-                    throw new RuntimeException("ERROR: Can't have multiple types of backbone flexibility for the same residue");
-                    //not supported, because current backbone DOF implementations depend on the DOF block
-                    //keeping track of the unperturbed backbone conformation, so if another type of motion
-                    //changes that unperturbed bb conf, then there will be errors
-                    //Mutations and sidechain dihedrals don't move the backbone so no issue there
-                }
-                else
-                    ans = flexTypeVox;
-            }
-            
-            if(ans.isEmpty())//no backbone flexibility
-                return new ArrayList(Arrays.asList(new HashMap<>()));
-            else
-                return ans;
+    private List<HashMap<String,double[]>> listBackboneVoxels(Position pos){
+        var bbVoxels = strandFlex.get(pos.strand)
+                                 .stream()
+                                 .map((flex) -> flex.listBackboneVoxels(pos))
+                                 .filter((lst) -> !lst.isEmpty())
+                                 .flatMap(Collection::stream)
+                                 .collect(Collectors.toList());
+
+        if (bbVoxels.size() > 1) {
+            throw new RuntimeException("ERROR: Can't have multiple types of backbone flexibility for the same residue");
+            //not supported, because current backbone DOF implementations depend on the DOF block
+            //keeping track of the unperturbed backbone conformation, so if another type of motion
+            //changes that unperturbed bb conf, then there will be errors
+            //Mutations and sidechain dihedrals don't move the backbone so no issue there
         }
+
+        return bbVoxels;
+    }
 
 	public SimpleConfSpace makeSubspace(Strand strand) {
 		return new Builder()


### PR DESCRIPTION
There was a bug that caused only the last configured bb region to have continuous flexibility.

Fixes #116 