### PR TITLE
Make field public

### DIFF
--- a/src/edu/duke/cs/osprey/ematrix/epic/EPICSettings.java
+++ b/src/edu/duke/cs/osprey/ematrix/epic/EPICSettings.java
@@ -67,7 +67,7 @@ public class EPICSettings implements Serializable {
     boolean useSAPE = true;
     boolean usePC = true;//use principal-component polynomials
     
-    boolean quadOnly = false;//use only quadratic polynomials + SAPE
+    public boolean quadOnly = false;//use only quadratic polynomials + SAPE
     
     public boolean minPartialConfs = true;//In A*, minimize sum of polynomial fits for partially
     //defined conformations, as well as for fully enumerated ones.  Increase A* lower bounds


### PR DESCRIPTION
It's used by the findGMEC.cats.py script, so it needs to be public.

Fixes #115 