### PR TITLE
Atom pair interactions

### DIFF
--- a/src/edu/duke/cs/osprey/energy/forcefield/AtomPairElectrostaticContribution.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/AtomPairElectrostaticContribution.java
@@ -1,0 +1,41 @@
+package edu.duke.cs.osprey.energy.forcefield;
+
+public class AtomPairElectrostaticContribution extends AtomPairEnergyContribution {
+
+	private final double radius;
+	private final double charge;
+	private final boolean is14Bonded;
+	private final boolean isHeavyPair;
+	private final boolean usesDistanceDependentDialectic;
+
+	public AtomPairElectrostaticContribution(ResPairCache.ResPair resPair, int atom1, int atom2, double energy,
+											 double radius, double charge, boolean is14Bonded,
+											 boolean isHeavyPair, boolean usesDistanceDependentDialectic) {
+		super(resPair, atom1, atom2, energy);
+		this.radius = radius;
+		this.charge = charge;
+		this.is14Bonded = is14Bonded;
+		this.isHeavyPair = isHeavyPair;
+		this.usesDistanceDependentDialectic = usesDistanceDependentDialectic;
+	}
+
+	public double getRadius() {
+		return radius;
+	}
+
+	public double getCharge() {
+		return charge;
+	}
+
+	public boolean isIs14Bonded() {
+		return is14Bonded;
+	}
+
+	public boolean isHeavyPair() {
+		return isHeavyPair;
+	}
+
+	public boolean isUsesDistanceDependentDialectic() {
+		return usesDistanceDependentDialectic;
+	}
+}

--- a/src/edu/duke/cs/osprey/energy/forcefield/AtomPairEnergyContribution.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/AtomPairEnergyContribution.java
@@ -1,0 +1,32 @@
+package edu.duke.cs.osprey.energy.forcefield;
+
+import edu.duke.cs.osprey.structure.Atom;
+
+public class AtomPairEnergyContribution {
+
+	public static final AtomPairEnergyContribution BrokenConformation = new AtomPairEnergyContribution(null, 0, 0, Double.POSITIVE_INFINITY);
+
+	private final int atom1;
+	private final int atom2;
+	private final double energy;
+	private final ResPairCache.ResPair resPair;
+
+	public AtomPairEnergyContribution(ResPairCache.ResPair resPair, int atom1, int atom2, double energy) {
+		this.resPair = resPair;
+		this.atom1 = atom1;
+		this.atom2 = atom2;
+		this.energy = energy;
+	}
+
+	public double getEnergy() {
+		return energy;
+	}
+
+	public Atom getAtom2() {
+		return resPair.res2.atoms.get(atom2);
+	}
+
+	public Atom getAtom1() {
+		return resPair.res1.atoms.get(atom1);
+	}
+}

--- a/src/edu/duke/cs/osprey/energy/forcefield/AtomPairSolvationContribution.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/AtomPairSolvationContribution.java
@@ -1,0 +1,8 @@
+package edu.duke.cs.osprey.energy.forcefield;
+
+public class AtomPairSolvationContribution extends AtomPairEnergyContribution {
+
+	public AtomPairSolvationContribution(ResPairCache.ResPair resPair, int atom1, int atom2, double energy) {
+		super(resPair, atom1, atom2, energy);
+	}
+}

--- a/src/edu/duke/cs/osprey/energy/forcefield/AtomPairVanDerWaalsContribution.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/AtomPairVanDerWaalsContribution.java
@@ -1,0 +1,28 @@
+package edu.duke.cs.osprey.energy.forcefield;
+
+public class AtomPairVanDerWaalsContribution extends AtomPairEnergyContribution {
+
+	private final double aij;
+	private final double bij;
+	private final double r2;
+
+	public AtomPairVanDerWaalsContribution(ResPairCache.ResPair resPair, int atom1, int atom2, double energy, double aij, double bij, double r2) {
+		super(resPair, atom1, atom2, energy);
+
+		this.aij = aij;
+		this.bij = bij;
+		this.r2 = r2;
+	}
+
+	public double getR2() {
+		return r2;
+	}
+
+	public double getBij() {
+		return bij;
+	}
+
+	public double getAij() {
+		return aij;
+	}
+}

--- a/src/edu/duke/cs/osprey/energy/forcefield/ResPairEnergyContribution.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/ResPairEnergyContribution.java
@@ -1,0 +1,37 @@
+package edu.duke.cs.osprey.energy.forcefield;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ResPairEnergyContribution {
+
+	public static final ResPairEnergyContribution BrokenConformation = new ResPairEnergyContribution(null, null);
+	private final ResPairCache.ResPair resPair;
+	private final List<AtomPairEnergyContribution> atomPairs;
+
+	public ResPairEnergyContribution(ResPairCache.ResPair resPair, List<AtomPairEnergyContribution> atomPairs) {
+		this.atomPairs = atomPairs;
+		this.resPair = resPair;
+	}
+
+	public double getEnergy() {
+		var energy = atomPairs.stream().map(AtomPairEnergyContribution::getEnergy).reduce(Double::sum).orElseThrow();
+		return (energy + resPair.offset + resPair.solvEnergy) * resPair.weight;
+	}
+
+	public ResPairCache.ResPair getResPair() {
+		return resPair;
+	}
+
+	public List<AtomPairEnergyContribution> getTopEnergyContributions(int n) {
+		return atomPairs.stream()
+				.sorted(Comparator.comparingDouble(AtomPairEnergyContribution::getEnergy).reversed())
+				.limit(n)
+				.collect(Collectors.toList());
+	}
+
+	public List<AtomPairEnergyContribution> getAtomPairEnergyContributions() {
+		return atomPairs;
+	}
+}

--- a/src/edu/duke/cs/osprey/energy/forcefield/ResidueForcefieldEnergy.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/ResidueForcefieldEnergy.java
@@ -32,11 +32,12 @@
 
 package edu.duke.cs.osprey.energy.forcefield;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import edu.duke.cs.osprey.dof.DegreeOfFreedom;
 import edu.duke.cs.osprey.energy.EnergyFunction;
 import edu.duke.cs.osprey.energy.ResidueInteractions;
@@ -45,9 +46,10 @@ import edu.duke.cs.osprey.energy.forcefield.ResPairCache.ResPair;
 import edu.duke.cs.osprey.structure.Molecule;
 import edu.duke.cs.osprey.structure.Residue;
 import edu.duke.cs.osprey.structure.Residues;
+import edu.duke.cs.osprey.tools.Streams;
 
 public class ResidueForcefieldEnergy implements EnergyFunction.DecomposableByDof {
-	
+
 	private static final long serialVersionUID = -4768384219061898745L;
 	
 	public final ResPairCache resPairCache;
@@ -56,7 +58,8 @@ public class ResidueForcefieldEnergy implements EnergyFunction.DecomposableByDof
 	
 	public final ResPair[] resPairs;
 	public final boolean isBroken;
-	
+	public static final List<ResPairEnergyContribution> brokenList = ImmutableList.of(ResPairEnergyContribution.BrokenConformation);
+
 	private double coulombFactor;
 	private double scaledCoulombFactor;
 	
@@ -112,6 +115,20 @@ public class ResidueForcefieldEnergy implements EnergyFunction.DecomposableByDof
 	@Override
 	public double getEnergy() {
 		return getEnergy(resPairs);
+	}
+
+	public List<ResPairEnergyContribution> getEnergyContributions(ResPair[] resPairs) {
+		var electrostaticContributions = getElectrostaticsEnergyContributions(resPairs);
+		var vdwContributions = getVanDerWaalsEnergyContributions(resPairs);
+		var solvationContributions = getSolvationEnergyContributions(resPairs);
+
+		var a = Streams.of(Iterables.concat(electrostaticContributions, vdwContributions, solvationContributions))
+				.collect(Collectors.groupingBy(ResPairEnergyContribution::getResPair,
+						Collectors.reducing((x, y)-> new ResPairEnergyContribution(x.getResPair(),
+								Stream.concat(x.getAtomPairEnergyContributions().stream(),
+										y.getAtomPairEnergyContributions().stream()).collect(Collectors.toList())))));
+
+		return a.values().stream().map(Optional::get).collect(Collectors.toList());
 	}
 	
 	private double getEnergy(ResPair[] resPairs) {
@@ -256,6 +273,84 @@ public class ResidueForcefieldEnergy implements EnergyFunction.DecomposableByDof
 		return getElectrostaticsEnergy(resPairs);
 	}
 
+	/**
+	 *
+	 * @param resPairs
+	 * @return A list of each of the atom pairs' individual contributions to overall electrostatic energy contribution.
+	 * Summing the individual contributions equals the total electrostatics contributions.
+	 */
+	public List<ResPairEnergyContribution> getElectrostaticsEnergyContributions(ResPair[] resPairs) {
+		// NOTE: this function isn't hammered like getEnergy() is, so performance isn't important here
+
+		if (isBroken) {
+			return brokenList;
+		}
+
+		var resPairContributions = new LinkedList<ResPairEnergyContribution>();
+
+		for (ResPair pair : resPairs) {
+
+			// for each atom pair...
+			int pos = 0;
+			var energyContributions = new LinkedList<AtomPairEnergyContribution>();
+
+			for (int j=0; j<pair.info.numAtomPairs; j++) {
+
+				double energy = 0;
+
+				// read the flags
+				long atomPairFlags = pair.info.flags[j];
+				int atomOffset2 = (int)(atomPairFlags & 0xffff);
+				atomPairFlags >>= 16;
+				int atomOffset1 = (int)(atomPairFlags & 0xffff);
+				atomPairFlags >>= 46;
+				boolean isHeavyPair = (atomPairFlags & 0x1) == 0x1;
+				atomPairFlags >>= 1;
+				boolean is14Bonded = (atomPairFlags & 0x1) == 0x1;
+
+				// get the radius
+				double r2 = getR2(pair, atomOffset1, atomOffset2);
+				double r = Math.sqrt(r2);
+				double charge = 0;
+
+				// compute the electrostatics
+				if (isHeavyPair || resPairCache.ffparams.hElect) {
+					charge = pair.info.precomputed[pos++];
+					if (is14Bonded) {
+						if (resPairCache.ffparams.distDepDielect) {
+							energy = scaledCoulombFactor*charge/r2;
+						} else {
+							energy = scaledCoulombFactor*charge/r;
+						}
+					} else {
+						if (resPairCache.ffparams.distDepDielect) {
+							energy = coulombFactor*charge/r2;
+						} else {
+							energy = coulombFactor*charge/r;
+						}
+					}
+				} else {
+					pos++;
+				}
+
+				// skip the van der Waals
+				pos += 2;
+
+				// skip the solvation precomputed values
+				if (resPairCache.ffparams.solvationForcefield == SolvationForcefield.EEF1) {
+					pos += 6;
+				}
+
+				energyContributions.add(new AtomPairElectrostaticContribution(pair, atomOffset1 / 3, atomOffset2 / 3,
+						energy, r, charge, is14Bonded, isHeavyPair, resPairCache.ffparams.distDepDielect));
+			}
+
+			resPairContributions.add(new ResPairEnergyContribution(pair, energyContributions));
+		}
+
+		return resPairContributions;
+	}
+
 	public double getElectrostaticsEnergy(ResPair[] resPairs) {
 
 		// NOTE: this function isn't hammered like getEnergy() is, so performance isn't important here
@@ -329,6 +424,65 @@ public class ResidueForcefieldEnergy implements EnergyFunction.DecomposableByDof
 		return getVanDerWaalsEnergy(resPairs);
 	}
 
+	public List<ResPairEnergyContribution> getVanDerWaalsEnergyContributions(ResPair[] resPairs) {
+
+		if (isBroken) {
+			return brokenList;
+		}
+
+		var resPairContributions = new LinkedList<ResPairEnergyContribution>();
+		for (ResPair pair : resPairs) {
+
+			var vanDerWaalsContributions = new LinkedList<AtomPairEnergyContribution>();
+			double energy = 0.0;
+
+			// for each atom pair...
+			int pos = 0;
+			for (int j=0; j<pair.info.numAtomPairs; j++) {
+
+				// read the flags
+				long atomPairFlags = pair.info.flags[j];
+				int atomOffset2 = (int)(atomPairFlags & 0xffff);
+				atomPairFlags >>= 16;
+				int atomOffset1 = (int)(atomPairFlags & 0xffff);
+				atomPairFlags >>= 46;
+				boolean isHeavyPair = (atomPairFlags & 0x1) == 0x1;
+
+				// skip the electrostatics precomputed values
+				pos += 1;
+
+				if (isHeavyPair || resPairCache.ffparams.hVDW) {
+
+					// get the radius
+					double r2 = getR2(pair, atomOffset1, atomOffset2);
+
+					double Aij = pair.info.precomputed[pos++];
+					double Bij = pair.info.precomputed[pos++];
+
+					// compute vdw
+					double r6 = r2*r2*r2;
+					double r12 = r6*r6;
+					energy = Aij/r12 - Bij/r6;
+
+					vanDerWaalsContributions.add(new AtomPairVanDerWaalsContribution(pair, atomOffset1 / 3,
+							atomOffset2 / 3, energy, Aij, Bij, r2));
+
+				} else {
+					pos += 2;
+				}
+
+				// skip the solvation precomputed values
+				if (resPairCache.ffparams.solvationForcefield == SolvationForcefield.EEF1) {
+					pos += 6;
+				}
+			}
+
+			resPairContributions.add(new ResPairEnergyContribution(pair, vanDerWaalsContributions));
+		}
+
+		return resPairContributions;
+	}
+
 	public double getVanDerWaalsEnergy(ResPair[] resPairs) {
 
 		// NOTE: this function isn't hammered like getEnergy() is, so performance isn't important here
@@ -391,6 +545,69 @@ public class ResidueForcefieldEnergy implements EnergyFunction.DecomposableByDof
 
 	public double getSolvationEnergy() {
 		return getSolvationEnergy(resPairs);
+	}
+
+	public List<ResPairEnergyContribution> getSolvationEnergyContributions(ResPair[] resPairs) {
+		if (isBroken) {
+			return brokenList;
+		}
+
+		var resPairContributions = new LinkedList<ResPairEnergyContribution>();
+
+		for (ResPair pair : resPairs) {
+
+			double resPairEnergy = 0;
+
+			// for each atom pair...
+			int pos = 0;
+			var atomPairContributions = new LinkedList<AtomPairEnergyContribution>();
+			for (int j=0; j<pair.info.numAtomPairs; j++) {
+
+				// read the flags
+				// NOTE: this is efficient, but destructive to the val
+				long atomPairFlags = pair.info.flags[j];
+				int atomOffset2 = (int)(atomPairFlags & 0xffff);
+				atomPairFlags >>= 16;
+				int atomOffset1 = (int)(atomPairFlags & 0xffff);
+				atomPairFlags >>= 46;
+				boolean isHeavyPair = (atomPairFlags & 0x1) == 0x1;
+				atomPairFlags >>= 1;
+				boolean is14Bonded = (atomPairFlags & 0x1) == 0x1;
+
+				// get the radius
+				double r2 = getR2(pair, atomOffset1, atomOffset2);
+				double r = Math.sqrt(r2);
+
+				// skip the vdW and electrostatics precomputed values
+				pos += 3;
+
+				// solvation
+				if (resPairCache.ffparams.solvationForcefield == SolvationForcefield.EEF1) {
+					if (isHeavyPair && r2 < ForcefieldParams.solvCutoff2) {
+
+						double radius1 = pair.info.precomputed[pos++];
+						double lambda1 = pair.info.precomputed[pos++];
+						double alpha1 = pair.info.precomputed[pos++];
+						double radius2 = pair.info.precomputed[pos++];
+						double lambda2 = pair.info.precomputed[pos++];
+						double alpha2 = pair.info.precomputed[pos++];
+
+						// compute solvation energy
+						double Xij = (r - radius1)/lambda1;
+						double Xji = (r - radius2)/lambda2;
+
+						var energy = -(alpha1*Math.exp(-Xij*Xij) + alpha2*Math.exp(-Xji*Xji))/r2;
+						atomPairContributions.add(new AtomPairSolvationContribution(pair, atomOffset1 / 3, atomOffset2 / 3, energy));
+
+					} else {
+						pos += 6;
+					}
+				}
+			}
+			resPairContributions.add(new ResPairEnergyContribution(pair, atomPairContributions));
+		}
+
+		return resPairContributions;
 	}
 
 	public double getSolvationEnergy(ResPair[] resPairs) {

--- a/src/edu/duke/cs/osprey/restypes/InterResBondingTemplate.java
+++ b/src/edu/duke/cs/osprey/restypes/InterResBondingTemplate.java
@@ -59,9 +59,7 @@ public abstract class InterResBondingTemplate implements Serializable {
     //atom is from this residue; can it bond other residues?
 
 	public abstract boolean isInterResBondedForward(Residue res1, Residue res2);
-	public abstract boolean makeInterResBondForward(Residue res1, Residue res2);
-
-    public static class NoBondingTemplate extends InterResBondingTemplate {
+	public static class NoBondingTemplate extends InterResBondingTemplate {
 
         //for residues that can't bond to anything else
         @Override
@@ -77,11 +75,7 @@ public abstract class InterResBondingTemplate implements Serializable {
         	return false;
 		}
 
-		@Override
-		public boolean makeInterResBondForward(Residue res1, Residue res2) {
-        	return false;
-		}
-    }
+	}
 
     public static class PeptideBondingTemplate extends InterResBondingTemplate {
 
@@ -117,22 +111,6 @@ public abstract class InterResBondingTemplate implements Serializable {
 			return C.bonds.contains(N);
 		}
 
-		@Override
-		public boolean makeInterResBondForward(Residue res1, Residue res2) {
-
-			// check for res1:C to res2:N bond
-			Atom C = res1.getAtomByName("C");
-			Atom N = res2.getAtomByName("N");
-
-			// no way to make a peptide bond? then fail
-			if (C == null || N == null) {
-				return false;
-			}
-
-			// don't worry if the atoms are too far apart, just make the bond
-			C.addBond(N);
-			return true;
-		}
 	}
 
 	public static class NucleotideBondingTemplate extends InterResBondingTemplate {
@@ -169,22 +147,6 @@ public abstract class InterResBondingTemplate implements Serializable {
 			return O.bonds.contains(P);
 		}
 
-		@Override
-		public boolean makeInterResBondForward(Residue res1, Residue res2) {
-
-			// check for res1:O3' to res2:P bond
-			Atom O = res1.getAtomByName("O3'");
-			Atom P = res2.getAtomByName("P");
-
-			// no way to make a nucleotide bond? then fail
-			if (O == null || P == null) {
-				return false;
-			}
-
-			// don't worry if the atoms are too far apart, just make the bond
-			O.addBond(P);
-			return true;
-		}
 	}
 
 
@@ -209,16 +171,6 @@ public abstract class InterResBondingTemplate implements Serializable {
             return atom.name.equalsIgnoreCase("N") || atom.name.equalsIgnoreCase("C")
                     || atom.name.equalsIgnoreCase("SG");
         }
-
-		@Override
-		public boolean isInterResBondedForward(Residue res1, Residue res2) {
-			throw new UnsupportedOperationException("atom connectivity queries for cysteine bonds are not yet implemented");
-		}
-
-		@Override
-		public boolean makeInterResBondForward(Residue res1, Residue res2) {
-			throw new UnsupportedOperationException("atom connectivity queries for cysteine bonds are not yet implemented");
-		}
 	}
 
 
@@ -271,11 +223,7 @@ public abstract class InterResBondingTemplate implements Serializable {
 			throw new UnsupportedOperationException(notSupportedMsg);
 		}
 
-		@Override
-		public boolean makeInterResBondForward(Residue res1, Residue res2) {
-			throw new UnsupportedOperationException(notSupportedMsg);
-		}
-    }
+	}
 
 
 

--- a/src/edu/duke/cs/osprey/structure/AtomConnectivity.java
+++ b/src/edu/duke/cs/osprey/structure/AtomConnectivity.java
@@ -224,7 +224,10 @@ public class AtomConnectivity {
 	}
 
 	private boolean isInterResBondedForward(Residue res1, Residue res2) {
-		return res1.template.interResBonding.getClass() == res2.template.interResBonding.getClass()
+		var class1 = res1.template.interResBonding.getClass();
+		var class2 = res2.template.interResBonding.getClass();
+
+		return (class1.isAssignableFrom(class2) || class2.isAssignableFrom(class1))
 			&& res1.template.interResBonding.isInterResBondedForward(res1, res2);
 	}
 


### PR DESCRIPTION
Jeff, could you please take a look? 

The new functions in `ResidueForcefieldEnergy` could largely replace the non-performance critical versions of the functions that return doubles (without removing them) by having the functions that return doubles reduce the lists returned by the new functions.

The lines relating to the cystine bonding are in `AtomConnectivity` and `InterResBondingTemplate`.  