### PR TITLE
Only submit score tasks when there are actually conformations to score.

### DIFF
--- a/src/edu/duke/cs/osprey/kstar/pfunc/GradientDescentPfunc.java
+++ b/src/edu/duke/cs/osprey/kstar/pfunc/GradientDescentPfunc.java
@@ -449,10 +449,12 @@ public class GradientDescentPfunc implements PartitionFunction.WithConfDB, Parti
 						confs.add(conf.getScore());
 					}
 
-					ecalc.tasks.submit(
-						new ScoreTask(instanceIdOrThrow(), confs, new Stopwatch().start()),
-						(result) -> onScores(result.scoreWeights, result.stopwatch.getTimeS())
-					);
+					if (!confs.isEmpty()) {
+						ecalc.tasks.submit(
+								new ScoreTask(instanceIdOrThrow(), confs, new Stopwatch().start()),
+								(result) -> onScores(result.scoreWeights, result.stopwatch.getTimeS())
+						);
+					}
 
 					break;
 				}


### PR DESCRIPTION
onScores() assumes that there are scores to read. If the first score in
the AStar tree is of infinite energy, then the list of scores to
evaluate is actually empty, and an index out of bounds exception is
thrown. This commit avoids that situation.

Fixes #144 